### PR TITLE
Fixing test for product-attribute/base_product_mass_addition

### DIFF
--- a/base_product_mass_addition/tests/test_product_mass_addition.py
+++ b/base_product_mass_addition/tests/test_product_mass_addition.py
@@ -2,9 +2,15 @@
 # @author Iván Todorovich <ivan.todorovich@camptocamp.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import datetime
+
 from odoo_test_helper import FakeModelLoader
 
 from odoo.tests.common import TransactionCase
+
+
+def now():
+    return datetime.now()
 
 
 class TestProductMassAddition(TransactionCase):
@@ -16,7 +22,12 @@ class TestProductMassAddition(TransactionCase):
         cls.loader.backup_registry()
         from .models.order import ModelOrder, ModelOrderLine
 
-        cls.loader.update_registry((ModelOrder, ModelOrderLine))
+        cls.loader.update_registry(
+            (
+                ModelOrder,
+                ModelOrderLine,
+            )
+        )
 
         # Setup data
         cls.order = cls.env["model.order"].create({})
@@ -24,11 +35,6 @@ class TestProductMassAddition(TransactionCase):
         cls.product = cls.env.ref("product.product_product_8").with_context(
             **cls.quick_ctx
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
 
     def test_quick_line_add(self):
         """Test quick lines are added, updated and removed"""
@@ -47,34 +53,39 @@ class TestProductMassAddition(TransactionCase):
 
     def test_quick_should_not_write_on_product(self):
         """Using quick magic fields shouldn't write on product's metadata"""
-        user_demo = self.env.ref("base.user_demo")
-        self.product.write_uid = user_demo
-        self.assertEqual(self.product.write_uid, user_demo)
+        # Monkey patch the now method for our testing purpose
+        # other the now method of cr would return the date of the Transaction
+        # which is unique for the whole test
+        self.env.cr.now = now
+        base_date = self.product.write_date
         # Case 1: Updating qty_to_process shouldn't write on products
-        self.product.qty_to_process = 1.0
-        self.assertEqual(self.product.write_uid, user_demo)
+        self.product.qty_to_process = 4.0
+        self.env["product.product"].flush_model()
+        self.assertEqual(base_date, self.product.write_date)
+        after_update_date = self.product.write_date
         # Case 2: Updating quick_uom_id shouldn't write on products
         self.product.quick_uom_id = self.env.ref("uom.product_uom_categ_unit").uom_ids[
             1
         ]
-        self.assertEqual(self.product.write_uid, user_demo)
+        self.env["product.product"].flush_model()
+        self.assertEqual(after_update_date, self.product.write_date)
 
     def test_quick_should_write_on_product(self):
         """Updating fields that are not magic fields should update
         product metadata"""
-        # Change the product write_uid for testing
-        user_demo = self.env.ref("base.user_demo")
-        self.product.write_uid = user_demo
-        self.assertEqual(self.product.write_uid, user_demo)
+        # Monkey patch the now method for our testing purpose
+        # other the now method of cr would return the date of the Transaction
+        # which is unique for the whole test
+        self.env.cr.now = now
+        base_date = self.product.write_date
         # Case 1: Updating name field should write on product's metadata
         self.product.name = "Testing"
-        self.assertEqual(self.product.write_uid, self.env.user)
-        # Change the product write_uid for testing
-        user_demo = self.env.ref("base.user_demo")
-        self.product.write_uid = user_demo
-        self.assertEqual(self.product.write_uid, user_demo)
+        self.env["product.product"].flush_model()
+        self.assertNotEqual(base_date, self.product.write_date)
+        after_update_date = self.product.write_date
         # Case 2: Updating qty_to_process and name before flush should
         # write on product's metadata
         self.product.qty_to_process = 2.0
         self.product.name = "Testing 2"
-        self.assertEqual(self.product.write_uid, self.env.user)
+        self.env["product.product"].flush_model()
+        self.assertNotEqual(after_update_date, self.product.write_date)


### PR DESCRIPTION
Hey @legalsylvain, I fixed the test for this as said in the original PR it is not possible to write to write_uid so by some trickery we can check the write_date to check if flush_model passes in the write method of the model